### PR TITLE
Add option to hide comments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Mountain Project Beta Videos",
-    "version": "1.1",
+    "version": "1.2",
   
     "description": "Adds a video gallery to routes with video links in the comments",
 
@@ -16,6 +16,14 @@
         "js": ["mpbv.js"],
         "css": ["mpbv.css"]
       }
+    ],
+
+    "options_ui": {
+      "page": "options.html"
+    },
+
+    "permissions": [
+      "storage"
     ],
 
     "browser_specific_settings": {

--- a/mpbv.css
+++ b/mpbv.css
@@ -1,7 +1,7 @@
 /*  
 Mountain Project Beta Videos
 Main CSS
-Version 1.1
+Version 1.2
 */
 
 #mpbv-videos {

--- a/mpbv.css
+++ b/mpbv.css
@@ -20,7 +20,7 @@ Version 1.1
   display: none;
 }
 
-.mpbv-note {
+#mpbv-note {
   padding-left: .5rem;
   font-size: .9rem;
   font-style: italic;

--- a/mpbv.js
+++ b/mpbv.js
@@ -1,11 +1,15 @@
 // Mountain Project Beta Videos
 // Main content script
-// Version 1.1
+// Version 1.2
 
 //Decalre constants
 const commentListIdBase =  'comments-Climb-Lib-Models-Route-';
 const linkRe = /youtu\.*be\.*\w*\/(?:watch\?v=)?([^\?&\s]*)/im;
 const baseEmbedUrl = 'https://www.youtube.com/embed/';
+
+const noteText = ' comments moved to video section )';
+const noteTextHidden = ' comments hidden | ';
+const unhideText= 'Show hidden comments';
 
 //Video class
 class Video {
@@ -43,6 +47,10 @@ function getVids() {
             let href = link.getAttribute('href');
             let ytLinks = linkRe.exec(href);
             if (ytLinks != null) {
+                if (hideComments) {
+                    comment.classList.add("mpbv-hidden");
+                    continue;
+                }
                 let url = baseEmbedUrl.concat(ytLinks[1]);
                 link.classList.add("mpbv-hidden");
                 let author,
@@ -97,22 +105,64 @@ function getVids() {
         let commentDiv = commentListDiv.parentElement;
         let parentDiv = commentDiv.parentElement;
         parentDiv.insertBefore(videosSection,commentDiv);
-
-        //Update comment count
-        let hiddenComments = commentListDiv.querySelectorAll("table.mpbv-hidden").length;
-        let newCommentsNum = comments.length - hiddenComments;
-        let commentHeader = commentListDiv.children[0];
-        commentHeader.children[0].innerText = newCommentsNum + ' Comments';
-
-        //Add note
-        let note = document.createElement('span');
-        note.className = "mpbv-note";
-        note.innerText = '( ' + hiddenComments + ' comments moved to video section )';
-        commentHeader.appendChild(note);
-        
-        
+ 
     } 
+
+    if (videoList.length >=1 || hideComments) {
+            //Update comment count
+            let hiddenComments = commentListDiv.querySelectorAll("table.mpbv-hidden").length;
+            let newCommentsNum = comments.length - hiddenComments;
+            let commentHeader = commentListDiv.children[0];
+            commentHeader.children[0].innerText = newCommentsNum + ' Comments';
+    
+            //Add note
+            let note = document.createElement('span');
+            note.id = "mpbv-note";
+            if (hideComments) {
+                let showButton = document.createElement('a');
+                let paren = document.createElement('span');
+                note.innerText = '( ' + hiddenComments + noteTextHidden;
+                showButton.innerText = unhideText;
+                showButton.onclick = restoreComments;
+                paren.innerText = " )";
+                note.appendChild(showButton);
+                note.appendChild(paren);
+            } else {
+                note.innerText = '( ' + hiddenComments + noteText;
+            }
+            commentHeader.appendChild(note);
+    }
 } 
+
+function restoreComments() {
+    //Remove hidden class and hide the note
+    let commentListDiv = document.getElementById(commentListId);
+    let comments = commentListDiv.getElementsByTagName("table");
+
+    for (const comment of comments) {
+        comment.classList.remove("mpbv-hidden");
+    }
+
+    let note = document.getElementById("mpbv-note");
+    note.classList.add("mpbv-hidden");
+}
+
+function onError(error) {
+    console.log(`Error: ${error}`);
+  }
+  
+function onGotSettings(item) {
+    if (item.hideComments) {
+      hideComments = item.hideComments;
+    }
+  }
+
+//  Init hideComments setting var
+let hideComments = false;
+ 
+// Get settings
+const getSettings = browser.storage.sync.get("hideComments");
+getSettings.then(onGotSettings, onError);
 
 // Listen for comments to finish loading
 const observer = new MutationObserver((mutationList) => {
@@ -123,7 +173,7 @@ const observer = new MutationObserver((mutationList) => {
     }
 });
 
-observer.observe(document.getElementById(commentListId), {
+observer.observe(document.getElementsByClassName("comment-list")[0], {
     childList: true,
     subtree: true,
 });

--- a/mpbv.js
+++ b/mpbv.js
@@ -2,6 +2,11 @@
 // Main content script
 // Version 1.2
 
+var browser;
+if (typeof browser === "undefined") {
+    browser = chrome;
+}
+
 //Decalre constants
 const commentListIdBase =  'comments-Climb-Lib-Models-Route-';
 const linkRe = /youtu\.*be\.*\w*\/(?:watch\?v=)?([^\?&\s]*)/im;

--- a/options.html
+++ b/options.html
@@ -3,15 +3,100 @@ Main content script
 Version 1.2 -->
 
 <!doctype html>
-<html lang="en" style="background-color: inherit;">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+        font-size: 3vw;
+        padding: 0 1em;
+      }
+
+      button {
+        margin: 1em 0;
+      }
+
+      .sub {
+        font-style: italic;
+        font-size: .8em;
+        margin: .5em 0;
+        padding: .5em 0;
+      }
+
+      .optionRow {
+        display: flex;
+      }
+
+      .optionRow span {
+        flex-grow: 2;
+      }
+
+      #submit_success.show {
+        display: inline !important;
+      }
+
+      #submit_success {
+        color: rgb(59, 121, 59);
+        font-style: italic;
+        font-size: .8em;
+        display: none;
+      }
+
+      .switch {
+        position: relative;
+        display: block;
+        width: 2.2em;
+        height: 1.2em;
+        background-color: rgba(0, 0, 0, 0.25);
+        border-radius: 1.2em;
+        transition: all 0.3s;
+      }
+      .switch::after {
+        content: '';
+        position: absolute;
+        width: 1em;
+        height: 1em;
+        border-radius:50%;
+        background-color: white;
+        top: .1em;
+        left: .1em;
+        transition: all 0.3s;
+      }
+
+      .checkbox:checked + .switch::after {
+        left : 1.1em;
+      }
+      .checkbox:checked + .switch {
+        background-color: #2359df;
+      }
+
+      .checkbox {
+        position: relative;
+        top: -.2em;
+        left: 3.6em;
+        z-index: 2;
+        opacity: 0;
+        width: 3.4em;
+        height: 1.7em;
+      }
+
+    </style>
   </head>
 
   <body>
     <form>
-      <label>Hide Comments <input type="checkbox" id="hideComments" name="hideComments" /></label>
-      <button type="submit">Save</button>
+      <div><h4>Mountain Project Beta Videos Settings</h4></div>
+      <div class="optionRow">
+        <span>Hide Comments</span>
+        <input type="checkbox" id="hideComments" name="hideComments" class="checkbox"/>
+        <label for="toggle" class="switch"></label>
+      </div>
+      <div class="sub">Enabling this option will hide all comments that contain youtube links. A link to restore them is also provided</div>
+      <div>
+        <button type="submit">Save</button>
+        <span id="submit_success">Successfully saved!</span>
+      </div>
     </form>
 
     <script src="options.js"></script>

--- a/options.html
+++ b/options.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" style="background-color: inherit;">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+
+  <body>
+    <form>
+      <label>Hide Comments <input type="checkbox" id="hideComments" name="hideComments" /></label>
+      <button type="submit">Save</button>
+    </form>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.html
+++ b/options.html
@@ -1,3 +1,7 @@
+<!-- Mountain Project Beta Videos
+Main content script
+Version 1.2 -->
+
 <!doctype html>
 <html lang="en" style="background-color: inherit;">
   <head>

--- a/options.js
+++ b/options.js
@@ -12,6 +12,10 @@ function saveOptions(e) {
     browser.storage.sync.set({
       hideComments: document.querySelector("#hideComments").checked,
     });
+    document.getElementById("submit_success").classList.add("show");
+    document.getElementById("hideComments").addEventListener("click", function(){
+      document.getElementById("submit_success").classList.remove("show");
+    })
   }
   
   function restoreOptions() {

--- a/options.js
+++ b/options.js
@@ -1,3 +1,12 @@
+// Mountain Project Beta Videos
+// Options script
+// Version 1.2
+
+var browser;
+if (typeof browser === "undefined") {
+    browser = chrome;
+}
+
 function saveOptions(e) {
     e.preventDefault();
     browser.storage.sync.set({

--- a/options.js
+++ b/options.js
@@ -1,0 +1,23 @@
+function saveOptions(e) {
+    e.preventDefault();
+    browser.storage.sync.set({
+      hideComments: document.querySelector("#hideComments").checked,
+    });
+  }
+  
+  function restoreOptions() {
+    function setCurrentChoice(result) {
+      document.querySelector("#hideComments").checked = result.hideComments || false;
+    }
+  
+    function onError(error) {
+      console.log(`Error: ${error}`);
+    }
+  
+    let getting = browser.storage.sync.get("hideComments");
+    getting.then(setCurrentChoice, onError);
+  }
+  
+  document.addEventListener("DOMContentLoaded", restoreOptions);
+  document.querySelector("form").addEventListener("submit", saveOptions);
+  


### PR DESCRIPTION
This PR does the following:

- Adds a option to hide comments rather than move them to a video gallery
- Adds a options page to control this setting

Tested in both Chrome and Firefox (latest versions)